### PR TITLE
Parameter parsing

### DIFF
--- a/pypiper/utils.py
+++ b/pypiper/utils.py
@@ -285,10 +285,17 @@ def get_parameter(param, param_pools, on_missing=None, error=True):
         to True.
     """
 
+
     # Search for the requested parameter.
-    for pool in param_pools:
+    for i, pool in enumerate(param_pools):
+        # DEBUG
+        print("POOL {}: {}".format(i, pool))
         if param in pool:
+            print("Matched: {}={}".format(param, pool[param]))
             return pool[param]
+        # DEBUG
+        else:
+            print("Unmapped: '{}'".format())
 
     # Raise error if unfound and no strategy or value is provided or handling
     # unmapped parameter requests.

--- a/pypiper/utils.py
+++ b/pypiper/utils.py
@@ -16,7 +16,7 @@ __email__ = "vreuter@virginia.edu"
 # What to export/attach to pypiper package namespace.
 # Conceptually, reserve this for functions expected to be used in other
 # packages, and import from utils within pypiper for other functions.
-__all__ = ["add_pypiper_args", "build_command"]
+__all__ = ["add_pypiper_args", "build_command", "get_parameter"]
 
 
 

--- a/pypiper/utils.py
+++ b/pypiper/utils.py
@@ -288,7 +288,7 @@ def get_parameter(param, param_pools, on_missing=None, error=True):
     # Search for the requested parameter.
     for pool in param_pools:
         if param in pool:
-            return param_pools[param]
+            return pool[param]
 
     # Raise error if unfound and no strategy or value is provided or handling
     # unmapped parameter requests.

--- a/pypiper/utils.py
+++ b/pypiper/utils.py
@@ -285,17 +285,10 @@ def get_parameter(param, param_pools, on_missing=None, error=True):
         to True.
     """
 
-
     # Search for the requested parameter.
-    for i, pool in enumerate(param_pools):
-        # DEBUG
-        print("POOL {}: {}".format(i, pool))
+    for pool in param_pools:
         if param in pool:
-            print("Matched: {}={}".format(param, pool[param]))
             return pool[param]
-        # DEBUG
-        else:
-            print("Unmapped: '{}'".format(param))
 
     # Raise error if unfound and no strategy or value is provided or handling
     # unmapped parameter requests.

--- a/pypiper/utils.py
+++ b/pypiper/utils.py
@@ -295,7 +295,7 @@ def get_parameter(param, param_pools, on_missing=None, error=True):
             return pool[param]
         # DEBUG
         else:
-            print("Unmapped: '{}'".format())
+            print("Unmapped: '{}'".format(param))
 
     # Raise error if unfound and no strategy or value is provided or handling
     # unmapped parameter requests.

--- a/pypiper/utils.py
+++ b/pypiper/utils.py
@@ -259,6 +259,55 @@ def flag_name(status):
 
 
 
+def get_parameter(param, param_pools, on_missing=None, error=True):
+    """
+    Get the value for a particular parameter.
+
+    Other than the parameter name itself, the other critical
+
+    :param str param: Name of parameter for which to determine/fetch value.
+    :param Sequence[Mapping[str, object]] param_pools: Ordered (priority)
+        collection of mapping from parameter name to value; this should be
+        ordered according to descending priority.
+    :param object | function(str) -> object on_missing: default value or
+        action to take if the requested parameter is missing from all of the
+        pools. If a callable, it should return a value when passed the
+        requested parameter as the one and only argument.
+    :param bool error: Whether to raise an error if the requested parameter
+        is not mapped to a value AND there's no value or strategy provided
+        with 'on_missing' with which to handle the case of a request for an
+        unmapped parameter.
+    :return object: Value to which the requested parameter first mapped in
+        the (descending) priority collection of parameter 'pools,' or
+        a value explicitly defined or derived with 'on_missing.'
+    :raise KeyError: If the requested parameter is unmapped in all of the
+        provided pools, and the argument to the 'error' parameter evaluates
+        to True.
+    """
+
+    # Search for the requested parameter.
+    for pool in param_pools:
+        if param in pool:
+            return param_pools[param]
+
+    # Raise error if unfound and no strategy or value is provided or handling
+    # unmapped parameter requests.
+    if error and on_missing is None:
+        raise KeyError("Unmapped parameter: '{}'".format(param))
+
+    # Use the value or strategy for handling unmapped parameter case.
+    try:
+        return on_missing(param)
+    except TypeError:
+        if hasattr(on_missing, "__call__"):
+            raise TypeError(
+                "Callable as argument for action in case of missing parameter "
+                "should be a function that returns a value when passed the "
+                "requested parameter as an argument.")
+        return on_missing
+
+
+
 def is_in_file_tree(fpath, folder):
     """
     Determine whether a file is in a folder.


### PR DESCRIPTION
I often come across a desire to be able to parse parameters from multiple places, in priority fashion, e.g. sample > command-line > pipeline_config. These changes facilitate that sort of thing, but in more general fashion, with any sort of prioritized collection of parameter-to-value mappings. Now used in `kallisto` pipeline with: https://github.com/databio/rnapipe/pull/4