### PR TITLE
Don't checkpoint a nofail stage when it's nofailed

### DIFF
--- a/pypiper/pipeline.py
+++ b/pypiper/pipeline.py
@@ -336,8 +336,9 @@ class Pipeline(object):
                 stage.run()
             except Exception as e:
                 self.manager._triage_error(e, nofail=stage.nofail)
+            else:
+                self.checkpoint(stage)
             self.executed.append(stage)
-            self.checkpoint(stage)
 
         # Add any unused stages to the collection of skips.
         self.skipped.extend(self._stages[stop_index:])


### PR DESCRIPTION
This makes it so that a "checkpoint" file marking a stage as complete is added _only_ if the stage actually succeeds, _not_ if it's bypassed due to be marked as `nofail`. Follow-up to #220 